### PR TITLE
Fix JSON property for Link's Rel field

### DIFF
--- a/link.go
+++ b/link.go
@@ -4,7 +4,7 @@ package webfinger
 type Link struct {
 	HRef       string             `json:"href"`
 	Type       string             `json:"type,omitempty"`
-	Rel        string             `json:"ref"`
+	Rel        string             `json:"rel"`
 	Properties map[string]*string `json:"properties,omitempty"`
 	Titles     map[string]string  `json:"titles,omitempty"`
 }


### PR DESCRIPTION
This fixes a typo -- previously the `Link.Rel` field would come out as `ref` in the JSON, instead of `rel`